### PR TITLE
fix: add custom disallowed elements to Markdown component and restore…

### DIFF
--- a/web/app/components/base/markdown.tsx
+++ b/web/app/components/base/markdown.tsx
@@ -239,7 +239,7 @@ const Link = ({ node, ...props }: any) => {
   }
 }
 
-export function Markdown(props: { content: string; className?: string }) {
+export function Markdown(props: { content: string; className?: string; customDisallowedElements?: string[] }) {
   const latexContent = flow([
     preprocessThinkTag,
     preprocessLaTeX,
@@ -274,7 +274,7 @@ export function Markdown(props: { content: string; className?: string }) {
             }
           },
         ]}
-        disallowedElements={['iframe', 'head', 'html', 'meta', 'link', 'style', 'body', 'input']}
+        disallowedElements={['iframe', 'head', 'html', 'meta', 'link', 'style', 'body', ...(props.customDisallowedElements || [])]}
         components={{
           code: CodeBlock,
           img: Img,

--- a/web/app/components/datasets/documents/detail/completed/common/chunk-content.tsx
+++ b/web/app/components/datasets/documents/detail/completed/common/chunk-content.tsx
@@ -181,6 +181,7 @@ const ChunkContent: FC<IChunkContentProps> = ({
       <Markdown
         className='h-full w-full !text-text-secondary'
         content={question}
+        customDisallowedElements={['input']}
       />
     )
   }

--- a/web/app/components/datasets/documents/detail/completed/segment-card/chunk-content.tsx
+++ b/web/app/components/datasets/documents/detail/completed/segment-card/chunk-content.tsx
@@ -50,6 +50,7 @@ const ChunkContent: FC<ChunkContentProps> = ({
       className,
     )}
     content={sign_content || content || ''}
+    customDisallowedElements={['input']}
   />
 }
 

--- a/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
+++ b/web/app/components/datasets/hit-testing/components/chunk-detail-modal.tsx
@@ -60,6 +60,7 @@ const ChunkDetailModal: FC<Props> = ({
           <Markdown
             className={cn('!mt-2 !text-text-secondary', heighClassName)}
             content={sign_content || content}
+            customDisallowedElements={['input']}
           />
           {!isParentChildRetrieval && keywords && keywords.length > 0 && (
             <div className='mt-6'>

--- a/web/app/components/datasets/hit-testing/components/result-item.tsx
+++ b/web/app/components/datasets/hit-testing/components/result-item.tsx
@@ -47,7 +47,11 @@ const ResultItem: FC<Props> = ({
 
       {/* Main */}
       <div className='mt-1 px-3'>
-        <Markdown className='line-clamp-2' content={sign_content || content} />
+        <Markdown
+          className='line-clamp-2'
+          content={sign_content || content}
+          customDisallowedElements={['input']}
+        />
         {isParentChildRetrieval && (
           <div className='mt-1'>
             <div


### PR DESCRIPTION
… the default disallowed elements (#15057)

# Summary

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

> [!Tip]
> Close issue syntax: `Fixes #<issue number>` or `Resolves #<issue number>`, see [documentation](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) for more details.


# Screenshots

| Before | After |
|--------|-------|
| ...    | ...   |

# Checklist

> [!IMPORTANT]  
> Please review the checklist below before submitting your pull request.

- [ ] This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x] I've updated the documentation accordingly.
- [x] I ran `dev/reformat`(backend) and `cd web && npx lint-staged`(frontend) to appease the lint gods

